### PR TITLE
Case insensitive url validation

### DIFF
--- a/url.go
+++ b/url.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
+	"regexp"
 	"time"
 )
 
 func validURL(url string) bool {
-	return strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "http://")
+	r := regexp.MustCompile("(?i)^http(?:s)?://")
+	return r.MatchString(url)
 }
 
 func getURL(url string) (io.Reader, error) {

--- a/url_test.go
+++ b/url_test.go
@@ -11,6 +11,7 @@ func TestValidURL(t *testing.T) {
 	}{
 		{"http://test.com", true},
 		{"https://test.com", true},
+		{"HttPs://test.com", true},
 		{"/test/test.com", false},
 		{"", false},
 	}


### PR DESCRIPTION
Not a huge issue but case insensitive matching for http(s) in urls seems like a good idea. Could use strings.HasPrefix with strings.ToLower but seems more cluttered 