### PR TITLE
allow insecure https connections

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -187,18 +187,21 @@ Usage:
 
 Options:
   -u, --ungron     Reverse the operation (turn assignments back into JSON)
+  -c, --colorize   Colorize output (default on tty)
   -m, --monochrome Monochrome (don't colorize output)
+  -s, --stream     Treat each line of input as a separate JSON object
+  -k, --insecure   Disable certificate validation
       --no-sort    Don't sort output (faster)
       --version    Print version information
 
 Exit Codes:
-  0 OK
-  1 Failed to open file
-  2 Failed to read input
-  3 Failed to form statements
-  4 Failed to fetch URL
-  5 Failed to parse statements
-  6 Failed to encode JSON
+  0	OK
+  1	Failed to open file
+  2	Failed to read input
+  3	Failed to form statements
+  4	Failed to fetch URL
+  5	Failed to parse statements
+  6	Failed to encode JSON
 
 Examples:
   gron /tmp/apiresponse.json

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func init() {
 		h += "  -c, --colorize   Colorize output (default on tty)\n"
 		h += "  -m, --monochrome Monochrome (don't colorize output)\n"
 		h += "  -s, --stream     Treat each line of input as a separate JSON object\n"
+		h += "  -k, --insecure   Disable certificate validation\n"
 		h += "      --no-sort    Don't sort output (faster)\n"
 		h += "      --version    Print version information\n\n"
 
@@ -88,6 +89,7 @@ func main() {
 		streamFlag     bool
 		noSortFlag     bool
 		versionFlag    bool
+		insecureFlag   bool
 	)
 
 	flag.BoolVar(&ungronFlag, "ungron", false, "")
@@ -100,6 +102,8 @@ func main() {
 	flag.BoolVar(&streamFlag, "stream", false, "")
 	flag.BoolVar(&noSortFlag, "no-sort", false, "")
 	flag.BoolVar(&versionFlag, "version", false, "")
+	flag.BoolVar(&insecureFlag, "k", false, "")
+	flag.BoolVar(&insecureFlag, "insecure", false, "")
 
 	flag.Parse()
 
@@ -123,7 +127,7 @@ func main() {
 			}
 			rawInput = r
 		} else {
-			r, err := getURL(filename)
+			r, err := getURL(filename,insecureFlag)
 			if err != nil {
 				fatal(exitFetchURL, err)
 			}

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 			}
 			rawInput = r
 		} else {
-			r, err := getURL(filename,insecureFlag)
+			r, err := getURL(filename, insecureFlag)
 			if err != nil {
 				fatal(exitFetchURL, err)
 			}

--- a/script/lint
+++ b/script/lint
@@ -12,4 +12,4 @@ fi
 
 # dupl is disabled because it has a habbit of identifying tests as duplicated code.
 # in its defence: it's right. gocyclo is disabled because I'm a terrible programmer.
-gometalinter --disable=gocyclo --disable=dupl --enable=mispell --enable=goimports
+gometalinter --disable=gocyclo --disable=dupl --enable=misspell --enable=goimports

--- a/script/lint
+++ b/script/lint
@@ -12,4 +12,6 @@ fi
 
 # dupl is disabled because it has a habbit of identifying tests as duplicated code.
 # in its defence: it's right. gocyclo is disabled because I'm a terrible programmer.
-gometalinter --disable=gocyclo --disable=dupl --enable=misspell --enable=goimports
+# gas is disabled because it doesn't like InsecureSkipVerify set to true for HTTP
+# requests - but we only do that if the user asks for it.
+gometalinter --disable=gocyclo --disable=dupl --enable=goimports --disable=gas

--- a/url.go
+++ b/url.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"bufio"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
 	"regexp"
 	"time"
-	"crypto/tls"
 )
 
 func validURL(url string) bool {
@@ -17,11 +17,11 @@ func validURL(url string) bool {
 
 func getURL(url string, insecure bool) (io.Reader, error) {
 	tr := &http.Transport{
-        		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-    		}
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+	}
 	client := http.Client{
 		Transport: tr,
-		Timeout: 20 * time.Second,
+		Timeout:   20 * time.Second,
 	}
 
 	req, err := http.NewRequest("GET", url, nil)

--- a/url.go
+++ b/url.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"regexp"
 	"time"
+	"crypto/tls"
 )
 
 func validURL(url string) bool {
@@ -14,8 +15,12 @@ func validURL(url string) bool {
 	return r.MatchString(url)
 }
 
-func getURL(url string) (io.Reader, error) {
+func getURL(url string, insecure bool) (io.Reader, error) {
+	tr := &http.Transport{
+        		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+    		}
 	client := http.Client{
+		Transport: tr,
 		Timeout: 20 * time.Second,
 	}
 


### PR DESCRIPTION
Added -k and --insecure flags to support insecure https connections

/script/test runs ok
/script/lint produces an additional warning about InsecureSkipVerify being true

I had to change /script/lint include from mispell to misspell for it to execute ¯\\\_(ツ)\_/¯
