### PR TITLE
Update ungron.go: fix bug: merge json.Number type

### DIFF
--- a/ungron.go
+++ b/ungron.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+        "reflect"
 
 	"github.com/pkg/errors"
 )
@@ -456,12 +457,12 @@ func recursiveMerge(a, b interface{}) (interface{}, error) {
 		}
 		return recursiveSliceMerge(a.([]interface{}), bSlice)
 
-	case string, int, float64, bool, nil:
+	case string, int, float64, bool, nil, json.Number:
 		// Can't merge them, second one wins
 		return b, nil
 
 	default:
-		return nil, fmt.Errorf("unexpected data type for merge")
+		return nil, fmt.Errorf("unexpected data type for merge: `%s`", reflect.TypeOf(a))
 	}
 }
 


### PR DESCRIPTION
The bug is when merging 2 numbers from 2 gron files / lines. 

Try this: 
```
echo -e "json.a=1;\njson.a=2;" | gron -u
```

You will fail with:
```
failed to merge statements: unexpected data type for merge
```

My fix: 
1. Gives a slightly more detailed message, telling you what type caused the failure.
2. After I saw that this type was `json.Number`, I have added it to the `case` statement of other number types.

After my fix you will see this output: 
```
{
  "a": 2
}
```