### PR TITLE
Allow running as ungron to perform --ungron automatically

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/mattn/go-colorable"
@@ -117,6 +118,11 @@ func main() {
 	if versionFlag {
 		fmt.Printf("gron version %s\n", gronVersion)
 		os.Exit(exitOK)
+	}
+
+	// If executed as 'ungron' set the --ungron flag
+	if strings.HasSuffix(os.Args[0], "ungron") {
+		ungronFlag = true
 	}
 
 	// Determine what the program's input should be:


### PR DESCRIPTION
The executable is normally executed as `gron` which performs the gron
operation. However, in order to install it as `ungron`, an alias is not
necessary as a symbolic link can be used instead. When the program
detects that it is being run as an executable called `ungron` then it
will automatically set the `--ungron` argument.