### PR TITLE
Adds "decode all" option

### DIFF
--- a/statements.go
+++ b/statements.go
@@ -398,6 +398,21 @@ func statementsFromJSON(r io.Reader, prefix statement) (statements, error) {
 	return ss, nil
 }
 
+// statementsFromJSONOffset takes an io.Reader containing JSON
+// and returns statements or an error on failure
+func statementsFromJSONOffset(r io.Reader, prefix statement) (statements, int64, error) {
+	var top interface{}
+	d := json.NewDecoder(r)
+	d.UseNumber()
+	err := d.Decode(&top)
+	if err != nil {
+		return nil, 0, err
+	}
+	ss := make(statements, 0, 32)
+	ss.fill(prefix, top)
+	return ss, d.InputOffset(), nil
+}
+
 // fill takes a prefix statement and some value and recursively fills
 // the statement list using that value
 func (ss *statements) fill(prefix statement, v interface{}) {


### PR DESCRIPTION
Adds: `-a`, `-all` flag which means "decode all the objects,
pretending it's a JSON stream even if it's not actually."

Rationale: `gron` only decodes the first object, `gron -s`
requires a "correctly" formatted JSON stream (one object per
line), but it's not uncommon to get multiple objects per line
with tools that don't support JSON stream formatting.

This does require a positionable stream, however, since the
JSON decoder can read past the end of an object to be sure its
parsed correctly.  `io.Seekable` doesn't work, unfortunately,
because whilst we know where we want to be (`d.InputOffset()`),
we don't actually know where we currently are which precludes
the use of `io.SeekCurrent` and, bizarrely, it turns out that
`io.SeekSet` gets progressively slower as you seek further and
further into your (in this case) `bytes.Buffer`.

Thus we keep track of where we want to be (`moved`) and create
a `bytes.NewReader` for each attempted decode at the correct
position.  Crufty, definitely, and memory-allocation heavy,
probably, but it works and is surprisingly not that bad even
on large files.

My test 85MB JSON single line input takes ~64s (x86_64),
~43s (arm64) and ~275M to parse into 1024 objects comprising
1GB of output text.  Compare to `jq`: ~25s (x86_64),
~11s (arm64) using ~630M giving 350MB of output.