### PR TITLE
`arm` build target

### DIFF
--- a/script/release
+++ b/script/release
@@ -28,10 +28,10 @@ fi
 
 FILELIST=""
 
-for ARCH in "amd64" "386" "arm64"; do
+for ARCH in "amd64" "386" "arm64" "arm"; do
     for OS in "darwin" "linux" "windows" "freebsd"; do
 
-        if [[ "${OS}" == "darwin" && "${ARCH}" == "386" ]]; then
+        if [[ "${OS}" == "darwin" && ("${ARCH}" == "386" || "${ARCH}" == "arm") ]]; then
             continue
         fi
 


### PR DESCRIPTION
This PR adds the `arm` build target. This fixes #95.

Currently the following build targets are available with go v1.18. Please notice that `darwin/arm` is not a valid build target, which is why I have excluded it.

```console
$ go tool dist list | grep arm
android/arm
android/arm64
darwin/arm64
freebsd/arm
freebsd/arm64
ios/arm64
linux/arm
linux/arm64
netbsd/arm
netbsd/arm64
openbsd/arm
openbsd/arm64
plan9/arm
windows/arm
windows/arm64
```