### PR TITLE
Add ldflags to 'go build' cmd to bring back version number

### DIFF
--- a/script/release
+++ b/script/release
@@ -43,7 +43,7 @@ for ARCH in "amd64" "386" "arm64"; do
 
         rm -f ${BINFILE}
 
-        GOOS=${OS} GOARCH=${ARCH} go build github.com/${USER}/${REPO}
+        GOOS=${OS} GOARCH=${ARCH} go build -ldflags "-X main.gronVersion=${VERSION}" github.com/${USER}/${REPO}
 
         if [[ "${OS}" == "windows" ]]; then
             ARCHIVE="${BINARY}-${OS}-${ARCH}-${VERSION}.zip"


### PR DESCRIPTION
In [v0.7.1](https://github.com/tomnomnom/gron/commit/badf401da553eb41b7ffde4be6a64809ed0ed846#diff-e3b83f8b89d67c5106cf02b79df582265e774eb93bbffb7e2ca26f05c73776dfL55) the `-ldflags "-X main.gronVersion=${VERSION}"` argument to the `go build` cmd has been removed. 

This PR reverts this change and re-introduces the flag to show the correct version string in the binary.

https://github.com/tomnomnom/gron/blob/13561bd6339bff18ba571e62313b3f5a6db00111/main.go#L47-L49

Closes #97