### PR TITLE
Add proxy capabilities

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,11 @@ var (
 // time with the ldflags -X option
 var gronVersion = "dev"
 
+// Default value that is set if proxy/noproxy variables is not specified.
+// Cannot be an empty string, because an empty string explicitly deactivates the
+// proxy.
+var undefinedProxy = "-"
+
 func init() {
 	flag.Usage = func() {
 		h := "Transform JSON (from a file, URL, or stdin) into discrete assignments to make it greppable\n\n"
@@ -63,6 +68,7 @@ func init() {
 		h += "  -s, --stream     Treat each line of input as a separate JSON object\n"
 		h += "  -k, --insecure   Disable certificate validation\n"
 		h += "  -x, --proxy      Set proxy configuration\n"
+		h += "      --noproxy    Comma-separated list of hosts for which not to use a proxy, if one is specified.\n"
 		h += "  -j, --json       Represent gron data as JSON stream\n"
 		h += "      --no-sort    Don't sort output (faster)\n"
 		h += "      --version    Print version information\n\n"
@@ -120,8 +126,8 @@ func main() {
 	flag.BoolVar(&valuesFlag, "value", false, "")
 	flag.BoolVar(&valuesFlag, "v", false, "")
 	flag.StringVar(&proxyURL, "x", "", "")
-	flag.StringVar(&proxyURL, "proxy", "", "")
-	flag.StringVar(&noProxy, "noproxy", "", "")
+	flag.StringVar(&proxyURL, "proxy", undefinedProxy, "")
+	flag.StringVar(&noProxy, "noproxy", undefinedProxy, "")
 
 	flag.Parse()
 
@@ -143,7 +149,7 @@ func main() {
 	if filename == "" || filename == "-" {
 		rawInput = os.Stdin
 	} else if validURL(filename) {
-		r, err := getURL(filename, insecureFlag, &proxyURL, &noProxy)
+		r, err := getURL(filename, insecureFlag, proxyURL, noProxy)
 		if err != nil {
 			fatal(exitFetchURL, err)
 		}

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func init() {
 		h += "  -m, --monochrome Monochrome (don't colorize output)\n"
 		h += "  -s, --stream     Treat each line of input as a separate JSON object\n"
 		h += "  -k, --insecure   Disable certificate validation\n"
+		h += "  -x, --proxy      Set proxy configuration\n"
 		h += "  -j, --json       Represent gron data as JSON stream\n"
 		h += "      --no-sort    Don't sort output (faster)\n"
 		h += "      --version    Print version information\n\n"
@@ -97,6 +98,8 @@ func main() {
 		insecureFlag   bool
 		jsonFlag       bool
 		valuesFlag     bool
+		proxyURL       string
+		noProxy        string
 	)
 
 	flag.BoolVar(&ungronFlag, "ungron", false, "")
@@ -116,6 +119,9 @@ func main() {
 	flag.BoolVar(&valuesFlag, "values", false, "")
 	flag.BoolVar(&valuesFlag, "value", false, "")
 	flag.BoolVar(&valuesFlag, "v", false, "")
+	flag.StringVar(&proxyURL, "x", "", "")
+	flag.StringVar(&proxyURL, "proxy", "", "")
+	flag.StringVar(&noProxy, "noproxy", "", "")
 
 	flag.Parse()
 
@@ -137,7 +143,7 @@ func main() {
 	if filename == "" || filename == "-" {
 		rawInput = os.Stdin
 	} else if validURL(filename) {
-		r, err := getURL(filename, insecureFlag)
+		r, err := getURL(filename, insecureFlag, &proxyURL, &noProxy)
 		if err != nil {
 			fatal(exitFetchURL, err)
 		}

--- a/url.go
+++ b/url.go
@@ -28,17 +28,18 @@ func configureProxy(url string, proxy string, noProxy string) func(*http.Request
 	if proxy == undefinedProxy {
 		proxy = os.Getenv(fmt.Sprintf("%s_proxy", cURL.Scheme))
 	}
+	if noProxy == undefinedProxy {
+		noProxy = os.Getenv("no_proxy")
+	}
+
+	// Skip setting a proxy if no proxy has been set through env variable or
+	// argument.
 	if proxy == "" {
-		// Skip setting a proxy if no proxy has been set through env variable or
-		// argument.
 		return nil
 	}
 
 	// Test if any of the hosts mentioned in the noProxy variable or the
 	// no_proxy env variable. Skip setting up the proxy if a match is found.
-	if noProxy == undefinedProxy {
-		noProxy = os.Getenv("no_proxy")
-	}
 	noProxyHosts := strings.Split(noProxy, ",")
 	if len(noProxyHosts) > 0 {
 		for _, noProxyHost := range noProxyHosts {

--- a/url_test.go
+++ b/url_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 )
 
@@ -21,5 +22,103 @@ func TestValidURL(t *testing.T) {
 		if have != test.want {
 			t.Errorf("Want %t for validURL(%s); have %t", test.want, test.url, have)
 		}
+	}
+}
+
+func TestConfigureProxyHttpWithEnv(t *testing.T) {
+	emptyStr := ""
+
+	tests := []struct {
+		url          string
+		httpProxy    *string
+		envHttpProxy string
+		noProxy      *string
+		envNoProxy   string
+		hasProxy     bool
+	}{
+		// http proxy via env variables
+		{"http://test1.com", nil, "http://localhost:1234", nil, "", true},
+		{"https://test1.com", nil, "http://localhost:1234", nil, "", false},
+		{"schema://test1.com", nil, "http://localhost:1234", nil, "", false},
+
+		// http proxy with env variables, overwritten by argument
+		{"http://test2.com", &emptyStr, "http://localhost:1234", nil, "", false},
+		{"https://test2.com", &emptyStr, "http://localhost:1234", nil, "", false},
+		{"schema://test2.com", &emptyStr, "http://localhost:1234", nil, "", false},
+
+		// http proxy with env variables, domain excluded by no_proxy
+		{"http://test3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
+		{"http://foobar3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
+		{"http://test.foobar3.com", nil, "http://localhost:1234", nil, ".foobar3.com", false},
+		{"https://test3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
+		{"schema://test3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
+
+		// http proxy with env variables, domain excluded by no_proxy, overwritten by argument
+		{"http://test4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", true},
+		{"http://foobar4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", true},
+		{"http://test.foobar4.com", nil, "http://localhost:1234", &emptyStr, ".foobar4.com", true},
+		{"https://test4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", false},
+		{"schema://test4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", false},
+	}
+
+	for _, test := range tests {
+		os.Setenv("http_proxy", test.envHttpProxy)
+		os.Setenv("no_proxy", test.envNoProxy)
+		proxy := configureProxy(test.url, test.httpProxy, test.noProxy)
+		hasProxy := proxy != nil
+		if hasProxy != test.hasProxy {
+			t.Errorf("Want %t for configureProxy; have %t; %v", test.hasProxy, hasProxy, test)
+		}
+		os.Unsetenv("http_proxy")
+		os.Unsetenv("no_proxy")
+	}
+}
+
+func TestConfigureProxyHttpsWithEnv(t *testing.T) {
+	emptyStr := ""
+
+	tests := []struct {
+		url           string
+		httpsProxy    *string
+		envHttpsProxy string
+		noProxy       *string
+		envNoProxy    string
+		hasProxy      bool
+	}{
+		// http proxy via env variables
+		{"http://test1.com", nil, "http://localhost:1234", nil, "", false},
+		{"https://test1.com", nil, "http://localhost:1234", nil, "", true},
+		{"schema://test1.com", nil, "http://localhost:1234", nil, "", false},
+
+		// http proxy with env variables, overwritten by argument
+		{"http://test2.com", &emptyStr, "http://localhost:1234", nil, "", false},
+		{"https://test2.com", &emptyStr, "http://localhost:1234", nil, "", false},
+		{"schema://test2.com", &emptyStr, "http://localhost:1234", nil, "", false},
+
+		// http proxy with env variables, domain excluded by no_proxy
+		{"http://test3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
+		{"http://foobar3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
+		{"http://test.foobar3.com", nil, "http://localhost:1234", nil, ".foobar3.com", false},
+		{"https://test3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
+		{"schema://test3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
+
+		// http proxy with env variables, domain excluded by no_proxy, overwritten by argument
+		{"http://test4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", false},
+		{"http://foobar4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", false},
+		{"http://test.foobar4.com", nil, "http://localhost:1234", &emptyStr, ".foobar4.com", false},
+		{"https://test4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", true},
+		{"schema://test4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", false},
+	}
+
+	for _, test := range tests {
+		os.Setenv("https_proxy", test.envHttpsProxy)
+		os.Setenv("no_proxy", test.envNoProxy)
+		proxy := configureProxy(test.url, test.httpsProxy, test.noProxy)
+		hasProxy := proxy != nil
+		if hasProxy != test.hasProxy {
+			t.Errorf("Want %t for configureProxy; have %t; %v", test.hasProxy, hasProxy, test)
+		}
+		os.Unsetenv("https_proxy")
+		os.Unsetenv("no_proxy")
 	}
 }

--- a/url_test.go
+++ b/url_test.go
@@ -25,40 +25,38 @@ func TestValidURL(t *testing.T) {
 	}
 }
 
-func TestConfigureProxyHttpWithEnv(t *testing.T) {
-	emptyStr := ""
-
+func TestConfigureProxyHttp(t *testing.T) {
 	tests := []struct {
 		url          string
-		httpProxy    *string
+		httpProxy    string
 		envHttpProxy string
-		noProxy      *string
+		noProxy      string
 		envNoProxy   string
 		hasProxy     bool
 	}{
 		// http proxy via env variables
-		{"http://test1.com", nil, "http://localhost:1234", nil, "", true},
-		{"https://test1.com", nil, "http://localhost:1234", nil, "", false},
-		{"schema://test1.com", nil, "http://localhost:1234", nil, "", false},
+		{"http://test1.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "", true},
+		{"https://test1.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "", false},
+		{"schema://test1.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "", false},
 
 		// http proxy with env variables, overwritten by argument
-		{"http://test2.com", &emptyStr, "http://localhost:1234", nil, "", false},
-		{"https://test2.com", &emptyStr, "http://localhost:1234", nil, "", false},
-		{"schema://test2.com", &emptyStr, "http://localhost:1234", nil, "", false},
+		{"http://test2.com", "", "http://localhost:1234", undefinedProxy, "", false},
+		{"https://test2.com", "", "http://localhost:1234", undefinedProxy, "", false},
+		{"schema://test2.com", "", "http://localhost:1234", undefinedProxy, "", false},
 
 		// http proxy with env variables, domain excluded by no_proxy
-		{"http://test3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
-		{"http://foobar3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
-		{"http://test.foobar3.com", nil, "http://localhost:1234", nil, ".foobar3.com", false},
-		{"https://test3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
-		{"schema://test3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
+		{"http://test3.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "test3.com,foobar3.com", false},
+		{"http://foobar3.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "test3.com,foobar3.com", false},
+		{"http://test.foobar3.com", undefinedProxy, "http://localhost:1234", undefinedProxy, ".foobar3.com", false},
+		{"https://test3.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "test3.com,foobar3.com", false},
+		{"schema://test3.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "test3.com,foobar3.com", false},
 
 		// http proxy with env variables, domain excluded by no_proxy, overwritten by argument
-		{"http://test4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", true},
-		{"http://foobar4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", true},
-		{"http://test.foobar4.com", nil, "http://localhost:1234", &emptyStr, ".foobar4.com", true},
-		{"https://test4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", false},
-		{"schema://test4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", false},
+		{"http://test4.com", undefinedProxy, "http://localhost:1234", "", "test4.com,foobar4.com", true},
+		{"http://foobar4.com", undefinedProxy, "http://localhost:1234", "", "test4.com,foobar4.com", true},
+		{"http://test.foobar4.com", undefinedProxy, "http://localhost:1234", "", ".foobar4.com", true},
+		{"https://test4.com", undefinedProxy, "http://localhost:1234", "", "test4.com,foobar4.com", false},
+		{"schema://test4.com", undefinedProxy, "http://localhost:1234", "", "test4.com,foobar4.com", false},
 	}
 
 	for _, test := range tests {
@@ -74,40 +72,38 @@ func TestConfigureProxyHttpWithEnv(t *testing.T) {
 	}
 }
 
-func TestConfigureProxyHttpsWithEnv(t *testing.T) {
-	emptyStr := ""
-
+func TestConfigureProxyHttps(t *testing.T) {
 	tests := []struct {
 		url           string
-		httpsProxy    *string
+		httpsProxy    string
 		envHttpsProxy string
-		noProxy       *string
+		noProxy       string
 		envNoProxy    string
 		hasProxy      bool
 	}{
-		// http proxy via env variables
-		{"http://test1.com", nil, "http://localhost:1234", nil, "", false},
-		{"https://test1.com", nil, "http://localhost:1234", nil, "", true},
-		{"schema://test1.com", nil, "http://localhost:1234", nil, "", false},
+		// https proxy via env variables
+		{"http://test1.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "", false},
+		{"https://test1.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "", true},
+		{"schema://test1.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "", false},
 
-		// http proxy with env variables, overwritten by argument
-		{"http://test2.com", &emptyStr, "http://localhost:1234", nil, "", false},
-		{"https://test2.com", &emptyStr, "http://localhost:1234", nil, "", false},
-		{"schema://test2.com", &emptyStr, "http://localhost:1234", nil, "", false},
+		// https proxy with env variables, overwritten by argument
+		{"http://test2.com", "", "http://localhost:1234", undefinedProxy, "", false},
+		{"https://test2.com", "", "http://localhost:1234", undefinedProxy, "", false},
+		{"schema://test2.com", "", "http://localhost:1234", undefinedProxy, "", false},
 
-		// http proxy with env variables, domain excluded by no_proxy
-		{"http://test3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
-		{"http://foobar3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
-		{"http://test.foobar3.com", nil, "http://localhost:1234", nil, ".foobar3.com", false},
-		{"https://test3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
-		{"schema://test3.com", nil, "http://localhost:1234", nil, "test3.com,foobar3.com", false},
+		// https proxy with env variables, domain excluded by no_proxy
+		{"http://test3.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "test3.com,foobar3.com", false},
+		{"http://foobar3.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "test3.com,foobar3.com", false},
+		{"http://test.foobar3.com", undefinedProxy, "http://localhost:1234", undefinedProxy, ".foobar3.com", false},
+		{"https://test3.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "test3.com,foobar3.com", false},
+		{"schema://test3.com", undefinedProxy, "http://localhost:1234", undefinedProxy, "test3.com,foobar3.com", false},
 
-		// http proxy with env variables, domain excluded by no_proxy, overwritten by argument
-		{"http://test4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", false},
-		{"http://foobar4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", false},
-		{"http://test.foobar4.com", nil, "http://localhost:1234", &emptyStr, ".foobar4.com", false},
-		{"https://test4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", true},
-		{"schema://test4.com", nil, "http://localhost:1234", &emptyStr, "test4.com,foobar4.com", false},
+		// https proxy with env variables, domain excluded by no_proxy, overwritten by argument
+		{"http://test4.com", undefinedProxy, "http://localhost:1234", "", "test4.com,foobar4.com", false},
+		{"http://foobar4.com", undefinedProxy, "http://localhost:1234", "", "test4.com,foobar4.com", false},
+		{"http://test.foobar4.com", undefinedProxy, "http://localhost:1234", "", ".foobar4.com", false},
+		{"https://test4.com", undefinedProxy, "http://localhost:1234", "", "test4.com,foobar4.com", true},
+		{"schema://test4.com", undefinedProxy, "http://localhost:1234", "", "test4.com,foobar4.com", false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR adds support for using a proxy when calling `gron <url>`. It allows to configure a proxy through the environment variables `http_proxy` and `https_proxy` and also respects values in the `no_proxy` environment variables. Users can always overwrite environment variables by using the two new cli arguments `-x/--proxy` or `--noproxy` to overwrite the environment variables (e.g., to disable the proxy). The behavior is similar to [curl's behavior](https://curl.se/docs/manual.html#environment-variables).

This PR fixes #89.

It's currently unclear to me if we should add some docs to this - either directly in the Readme or maybe in the advanced section.