### PR TITLE
Adds Bash completions file

### DIFF
--- a/completions/gron.bash
+++ b/completions/gron.bash
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Bash shell commandline completions for gron.
+#
+# Copy the contents of this file into your ~/.bashrc file or whatever
+# file you use for Bash completions.
+#
+# Example: cat ./completions/gron.bash >> ~/.bashrc
+
+function _gron_completion {
+  local AVAILABLE_COMMANDS="--colorize --insecure --json --monochrome --no-sort --stream --ungron --values --version"
+  COMPREPLY=()
+
+  local CURRENT_WORD=${COMP_WORDS[COMP_CWORD]}
+  COMPREPLY=($(compgen -W "$AVAILABLE_COMMANDS" -- "$CURRENT_WORD"))
+}
+
+complete -F _gron_completion gron


### PR DESCRIPTION
This PR piggybacks on the work started in https://github.com/tomnomnom/gron/pull/113 (which seems to have stalled out) to add a file which performs Bash completions (https://github.com/tomnomnom/gron/issues/112).

Here's an example of me using it locally:

```shell
[21:16] widget ~ $ gron --
--colorize    --insecure    --json        --monochrome  --no-sort     --stream      --ungron      --values      --version
[21:16] widget ~ $ gron --
```